### PR TITLE
fix: scale from zero may take too long

### DIFF
--- a/gateway/handlers/scaling.go
+++ b/gateway/handlers/scaling.go
@@ -65,6 +65,11 @@ func MakeScalingHandler(next http.HandlerFunc, scaler scaling.FunctionScaler, co
 			return
 		}
 
-		log.Printf("[Scale] function=%s.%s 0=>N timed-out after %fs\n", functionName, namespace, res.Duration.Seconds())
+		errStr := fmt.Sprintf("function=%s.%s 0=>N timed-out\n", functionName, namespace)
+		log.Printf("Scaling: %s\n", errStr)
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(errStr))
+		return
 	}
 }

--- a/gateway/handlers/scaling.go
+++ b/gateway/handlers/scaling.go
@@ -34,8 +34,8 @@ func MakeScalingHandler(next http.HandlerFunc, scaler scaling.FunctionScaler, co
 		res := scaler.Scale(functionName, namespace)
 		for tryChance := 9; tryChance > 0; tryChance-- {
 			if !res.Available {
-				time.Sleep(time.Millisecond * 5000)
 				log.Printf("Function unavailabel after scale, but I still get %d more chances to try", tryChance)
+				time.Sleep(time.Millisecond * 5000)
 				res = scaler.Scale(functionName, namespace)
 				continue
 			}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -136,7 +136,7 @@ func main() {
 	scalingConfig := scaling.ScalingConfig{
 		MaxPollCount:         uint(1000),
 		SetScaleRetries:      uint(20),
-		FunctionPollInterval: time.Millisecond * 200,
+		FunctionPollInterval: time.Millisecond * 500,
 		CacheExpiry:          time.Second * 5, // freshness of replica values before going stale
 		ServiceQuery:         externalServiceQuery,
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -136,7 +136,7 @@ func main() {
 	scalingConfig := scaling.ScalingConfig{
 		MaxPollCount:         uint(1000),
 		SetScaleRetries:      uint(20),
-		FunctionPollInterval: time.Millisecond * 50,
+		FunctionPollInterval: time.Millisecond * 200,
 		CacheExpiry:          time.Second * 5, // freshness of replica values before going stale
 		ServiceQuery:         externalServiceQuery,
 	}

--- a/gateway/scaling/function_scaler.go
+++ b/gateway/scaling/function_scaler.go
@@ -110,7 +110,7 @@ func (f *FunctionScaler) Scale(functionName, namespace string) FunctionScaleResu
 					Duration:  totalTime,
 				}
 			}
-			if totalTime > time.Second * 30 {
+			if totalTime > (time.Second * 30) {
 				log.Printf("Scale function timeout, duration: %d", totalTime)
 				return FunctionScaleResult{
 					Error:     nil,
@@ -119,7 +119,7 @@ func (f *FunctionScaler) Scale(functionName, namespace string) FunctionScaleResu
 					Duration:  totalTime,
 				}
 			}
-			
+
 			if err != nil {
 				return FunctionScaleResult{
 					Error:     err,


### PR DESCRIPTION
this PR including:
 - limit the waiting time of scale from zero
 - increase function poll interval (to reduce k8s api server loading)
 - response 503 if scaling function failed